### PR TITLE
Fixes for docker configuration when running on macOS (darwin) Mojave

### DIFF
--- a/lib/sphinx-preview.js
+++ b/lib/sphinx-preview.js
@@ -3,6 +3,8 @@
 import { CompositeDisposable } from 'atom';
 import Docker from 'dockerode';
 
+const os = require('os');
+
 export default {
 
   subscriptions: null,
@@ -36,7 +38,20 @@ export default {
   },
 
   getBindingPath() {
-    return `/${atom.project.getPaths()[0].replace(/[/\\*]/g, '/').replace(':', '')}`; // WINDOWS
+    // == DARWIN DOCKER FIX [1/2] === -- BEGIN --
+    // Lines below were changed in order to fix filesystem-related issues
+    // preventing python-livereload's file watcher from running correctly 
+    // when docker host is macOS (darwin) Mojave
+
+    var path = `${atom.project.getPaths()[0].replace(/[/\\*]/g, '/').replace(':', '')}`;
+
+    if(os.platform() === 'win32') {
+      path = `/${path}`;
+    }
+
+    return path;
+
+    // == DARWIN DOCKER FIX [1/2] === -- END --
   },
 
   startSphinxServer(onStart) {
@@ -85,11 +100,30 @@ export default {
             '8000/tcp': [{
               HostPort: '8000',
             }],
-            '35729/tcp': [{
-              HostPort: '35729',
-            }],
           },
+
+        // == DARWIN DOCKER FIX [2/2] === -- BEGIN --
+        // Lines below were added in order to fix filesystem-related issues
+        // preventing python-livereload's file watcher from running correctly 
+        // when docker host is macOS (darwin) Mojave
+          
+          Devices: [ ],
+          BlkioWeightDevice: [ ],
+
+          Dns: [ ],
+          DnsOptions: [ ],
+          DnsSearch: [ ],
+
+          RestartPolicy: {
+            Name: "no",
+            MaximumRetryCount: 0,
+          }
         },
+
+        Tty: true,
+        OpenStdin: true,
+
+        // == DARWIN DOCKER FIX [2/2] === -- END --
       };
 
       atom.notifications.addInfo('Pulling last version of Sphinx-Server (this may take a while)');

--- a/lib/sphinx-preview.js
+++ b/lib/sphinx-preview.js
@@ -2,8 +2,7 @@
 
 import { CompositeDisposable } from 'atom';
 import Docker from 'dockerode';
-
-const os = require('os');
+import * as os from 'os';
 
 export default {
 
@@ -43,9 +42,9 @@ export default {
     // preventing python-livereload's file watcher from running correctly 
     // when docker host is macOS (darwin) Mojave
 
-    var path = `${atom.project.getPaths()[0].replace(/[/\\*]/g, '/').replace(':', '')}`;
+    let path = `${atom.project.getPaths()[0].replace(/[/\\*]/g, '/').replace(':', '')}`;
 
-    if(os.platform() === 'win32') {
+    if (os.platform() === 'win32') {
       path = `/${path}`;
     }
 
@@ -104,7 +103,7 @@ export default {
 
         // == DARWIN DOCKER FIX [2/2] === -- BEGIN --
         // Lines below were added in order to fix filesystem-related issues
-        // preventing python-livereload's file watcher from running correctly 
+        // preventing python-livereload's file watcher from running correctly
         // when docker host is macOS (darwin) Mojave
           
           Devices: [ ],


### PR DESCRIPTION
Potentially (aka works on my macOS Mojave machine) fixes #14

`python-reload`'s file watcher behaves erratically when run in a docker environment when the host is macOS (darwin) Mojave, I believe it may be a bug either in the docker engine itself or in the darwin kernel when handling `//double/slash/posix-n-win32-compatible/paths`, as well as differing configuration.

This patch is based on having run `docker inspect` on the container as launched form the `sphinx-preview` plugin and as launched from the command line.

I have not encountered the problems mentioned in #14 with these patches, however given the erratic nature of the error it is very difficult to test in an automated way.